### PR TITLE
Moving pandoc install before package check

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,9 +25,11 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
-
-      - uses: r-lib/actions/check-r-package@v2
+          
       - uses: r-lib/actions/setup-pandoc@v2
         with:
           pandoc-version: '2.17.1' # The pandoc version to download (if necessary) and use.
       - run: echo "# Test" | pandoc -t html
+
+      - uses: r-lib/actions/check-r-package@v2
+


### PR DESCRIPTION
I'm wondering if changing the order of the GitHub Action steps might make a difference. i.e. install pandoc before the check